### PR TITLE
Fix examples, docs and bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "glium_text_rusttype"
-version = "0.0.2"
-authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "Fedor Logachev <not.fl3@gmail.com>"]
+version = "0.0.3"
+authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "Fedor Logachev <not.fl3@gmail.com>", "Constantine Shablya <t3a@protonmailc.om"]
 description = "glium_text fork, text drawing with glium and rusttype"
 documentation = "https://docs.rs/glium_text_rusttype"
 repository = "https://github.com/not-fl3/glium_text_rusttype"
@@ -9,16 +9,15 @@ keywords = ["text", "opengl"]
 license = "MIT"
 
 [dependencies]
-rusttype = "0.2.1"
-libc = "0.2"
+rusttype = "0.2"
 
 [dependencies.glium]
-version = "0.15"
+version = "0.16"
 default-features = false
 
 [dev-dependencies]
-cgmath = "0.10"
+cgmath = "0.14"
 
 [dev-dependencies.glium]
-version = "0.15"
+version = "0.16"
 features = ["glutin"]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,5 @@
 extern crate glium;
-extern crate glium_text;
+extern crate glium_text_rusttype as glium_text;
 extern crate cgmath;
 
 use std::thread;

--- a/examples/user_text.rs
+++ b/examples/user_text.rs
@@ -1,5 +1,5 @@
 extern crate glium;
-extern crate glium_text;
+extern crate glium_text_rusttype as glium_text;
 extern crate cgmath;
 
 use std::path::Path;
@@ -16,11 +16,11 @@ fn main() {
     let system = glium_text::TextSystem::new(&display);
 
     let font = match std::env::args().nth(1) {
-        Some(file) => glium_text::FontTexture::new(&display, File::open(&Path::new(&file)).unwrap(), 70),
+        Some(file) => glium_text::FontTexture::new(&display, File::open(&Path::new(&file)).unwrap(), 70, glium_text::FontTexture::ascii_character_list()),
         None => {
             match File::open(&Path::new("C:\\Windows\\Fonts\\Arial.ttf")) {
-                Ok(f) => glium_text::FontTexture::new(&display, f, 70),
-                Err(_) => glium_text::FontTexture::new(&display, &include_bytes!("font.ttf")[..], 70),
+                Ok(f) => glium_text::FontTexture::new(&display, f, 70, glium_text::FontTexture::ascii_character_list()),
+                Err(_) => glium_text::FontTexture::new(&display, &include_bytes!("font.ttf")[..], 70, glium_text::FontTexture::ascii_character_list()),
             }
         }
     }.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ Usage:
 
 ```no_run
 # extern crate glium;
-# extern crate glium_text;
+# extern crate glium_text_rusttype as glium_text;
 # extern crate cgmath;
 # fn main() {
 # let display: glium::Display = unsafe { std::mem::uninitialized() };
@@ -15,7 +15,7 @@ let system = glium_text::TextSystem::new(&display);
 
 // Creating a `FontTexture`, which a regular `Texture` which contains the font.
 // Note that loading the systems fonts is not covered by this library.
-let font = glium_text::FontTexture::new(&display, std::fs::File::open(&std::path::Path::new("my_font.ttf")).unwrap(), 24).unwrap();
+let font = glium_text::FontTexture::new(&display, std::fs::File::open(&std::path::Path::new("my_font.ttf")).unwrap(), 24, glium_text::FontTexture::ascii_character_list()).unwrap();
 
 // Creating a `TextDisplay` which contains the elements required to draw a specific sentence.
 let text = glium_text::TextDisplay::new(&system, &font, "Hello world!");
@@ -33,7 +33,6 @@ glium_text::draw(&text, &system, &mut display.draw(), matrix, (1.0, 1.0, 0.0, 1.
 
 #![warn(missing_docs)]
 
-extern crate libc;
 extern crate rusttype;
 #[macro_use]
 extern crate glium;
@@ -122,6 +121,7 @@ struct VertexFormat {
 implement_vertex!(VertexFormat, position, tex_coords);
 
 impl FontTexture {
+    /// Vec<char> of complete ASCII range (from 0 to 255 bytes)
     pub fn ascii_character_list() -> Vec<char> {
         (0 .. 255).filter_map(|c| ::std::char::from_u32(c)).collect()
     }


### PR DESCRIPTION
Examples in src/lib.rs and examples/* were fixed and are working, `FontTexture::ascii_character_list()` now has a doc string.  Packages also were bumped to their newer versions.  Got rid of useless libc dependency.