### PR TITLE
Enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium_text_rusttype"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "Fedor Logachev <not.fl3@gmail.com>", "Constantine Shablya <t3a@protonmail.com>"]
 description = "glium_text fork, text drawing with glium and rusttype"
 documentation = "https://docs.rs/glium_text_rusttype"

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -33,7 +33,7 @@ fn main() {
 
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 1.0);
-        glium_text::draw(&text, &system, &mut target, matrix, (1.0, 1.0, 0.0, 1.0));
+        glium_text::draw(&text, &system, &mut target, matrix, (1.0, 1.0, 0.0, 1.0)).unwrap();
         target.finish().unwrap();
 
         thread::sleep(sleep_duration);

--- a/examples/user_text.rs
+++ b/examples/user_text.rs
@@ -17,12 +17,7 @@ fn main() {
 
     let font = match std::env::args().nth(1) {
         Some(file) => glium_text::FontTexture::new(&display, File::open(&Path::new(&file)).unwrap(), 70, glium_text::FontTexture::ascii_character_list()),
-        None => {
-            match File::open(&Path::new("C:\\Windows\\Fonts\\Arial.ttf")) {
-                Ok(f) => glium_text::FontTexture::new(&display, f, 70, glium_text::FontTexture::ascii_character_list()),
-                Err(_) => glium_text::FontTexture::new(&display, &include_bytes!("font.ttf")[..], 70, glium_text::FontTexture::ascii_character_list()),
-            }
-        }
+        None => glium_text::FontTexture::new(&display, &include_bytes!("font.ttf")[..], 70, glium_text::FontTexture::ascii_character_list()),
     }.unwrap();
 
     let mut buffer = String::new();
@@ -45,7 +40,7 @@ fn main() {
 
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 1.0);
-        glium_text::draw(&text, &system, &mut target, matrix, (1.0, 1.0, 0.0, 1.0));
+        glium_text::draw(&text, &system, &mut target, matrix, (1.0, 1.0, 0.0, 1.0)).unwrap();
         target.finish().unwrap();
 
         thread::sleep(sleep_duration);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@ fn build_font_image<I>(font: rusttype::Font, characters_list: I, font_size: u32)
     const MARGIN: u32 = 2;
 
     // glyph size for characters not presented in font.
-    let invalid_character_width = font_size / 4;
+    let invalid_character_width = font_size / 2;
 
     let size_estimation = characters_list.size_hint().1.unwrap_or(0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,9 +139,8 @@ impl FontTexture {
         let font = collection.into_font().unwrap();
 
         // building the infos
-        let (texture_data, chr_infos) = unsafe {
-            build_font_image(font, characters_list.into_iter().collect(), font_size)
-        };
+        let (texture_data, chr_infos) =
+            build_font_image(font, characters_list.into_iter().collect(), font_size);
 
         // we load the texture in the display
         let texture = glium::texture::Texture2d::new(facade, &texture_data).unwrap();
@@ -448,8 +447,8 @@ pub fn draw_with_params<F, S: ?Sized, M>(
     target.draw(vertex_buffer, index_buffer, &system.program, &uniforms, &parameters)
 }
 
-unsafe fn build_font_image(font: rusttype::Font, characters_list: Vec<char>, font_size: u32)
-                           -> (TextureData, Vec<(char, CharacterInfos)>)
+fn build_font_image(font: rusttype::Font, characters_list: Vec<char>, font_size: u32)
+                    -> (TextureData, Vec<(char, CharacterInfos)>)
 {
     use std::iter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,9 @@ impl FontTexture {
     }
 
     /// Creates a new texture representing a font stored in a `FontTexture`.
-    pub fn new<R, F>(facade: &F, font: R, font_size: u32, characters_list : Vec<char>)
-                     -> Result<FontTexture, ()> where R: Read, F: Facade
+    pub fn new<R, F, I>(facade: &F, font: R, font_size: u32, characters_list: I)
+                        -> Result<FontTexture, ()>
+        where R: Read, F: Facade, I: IntoIterator<Item=char>
     {
 
         // building the freetype face object
@@ -139,7 +140,7 @@ impl FontTexture {
 
         // building the infos
         let (texture_data, chr_infos) = unsafe {
-            build_font_image(font, characters_list, font_size)
+            build_font_image(font, characters_list.into_iter().collect(), font_size)
         };
 
         // we load the texture in the display

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,19 +37,21 @@ extern crate rusttype;
 #[macro_use]
 extern crate glium;
 
-use glium::DrawParameters;
-use glium::backend::Context;
-use glium::backend::Facade;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::default::Default;
 use std::io::Read;
 use std::ops::Deref;
 use std::rc::Rc;
 
+use glium::DrawParameters;
+use glium::backend::Context;
+use glium::backend::Facade;
+
 /// Texture which contains the characters of the font.
 pub struct FontTexture {
     texture: glium::texture::Texture2d,
-    character_infos: Vec<(char, CharacterInfos)>,
+    character_infos: HashMap<char, CharacterInfos>,
 }
 
 /// Object that contains the elements shared by all `TextDisplay` objects.
@@ -147,7 +149,7 @@ impl FontTexture {
 
         Ok(FontTexture {
             texture: texture,
-            character_infos: chr_infos,
+            character_infos: chr_infos.into_iter().collect(),
         })
     }
 }
@@ -276,14 +278,11 @@ impl<F> TextDisplay<F> where F: Deref<Target=FontTexture> {
         let mut index_buffer_data = Vec::with_capacity(text.len() * 6);
 
         // iterating over the characters of the string
-        for character in text.chars() {     // FIXME: wrong, but only thing stable
-            let infos = match self.texture.character_infos
-                .iter().find(|&&(chr, _)| chr == character)
-            {
+        for character in text.chars() {
+            let infos = match self.texture.character_infos.get(&character) {
                 Some(infos) => infos,
-                None => continue        // character not found in the font, ignoring it
+                None => continue,
             };
-            let infos = infos.1;
 
             self.is_empty = false;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,12 +509,6 @@ fn build_font_image(font: rusttype::Font, characters_list: Vec<char>, font_size:
         // adding a left margin before our character to prevent artifacts
         cursor_offset.0 += MARGIN;
 
-        // computing em_pixels
-        // FIXME: this is hacky
-        if character == 'M' {
-            em_pixels = bitmap.rows as f32;
-        }
-
         // carriage return our cursor if we don't have enough room to write the next caracter
         // we add a margin to prevent artifacts
         if cursor_offset.0 + (bitmap.width as u32) + MARGIN >= texture_width {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,7 +473,7 @@ fn build_font_image(font: rusttype::Font, characters_list: Vec<char>, font_size:
     let mut rows_to_skip = 0u32;
 
     // now looping through the list of characters, filling the texture and returning the informations
-    let mut em_pixels = font_size as f32;
+    let em_pixels = font_size as f32;
     let mut characters_infos: Vec<(char, CharacterInfos)> = characters_list.into_iter().filter_map(|character| {
         struct Bitmap {
             rows   : i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ Usage:
 # extern crate glium;
 # extern crate glium_text_rusttype as glium_text;
 # extern crate cgmath;
+# use std::fs::File;
 # fn main() {
 # let display: glium::Display = unsafe { std::mem::uninitialized() };
 // The `TextSystem` contains the shaders and elements used for text display.
@@ -15,7 +16,12 @@ let system = glium_text::TextSystem::new(&display);
 
 // Creating a `FontTexture`, which a regular `Texture` which contains the font.
 // Note that loading the systems fonts is not covered by this library.
-let font = glium_text::FontTexture::new(&display, std::fs::File::open(&std::path::Path::new("my_font.ttf")).unwrap(), 24, glium_text::FontTexture::ascii_character_list()).unwrap();
+let font = glium_text::FontTexture::new(
+    &display,
+    File::open("font.ttf").unwrap(),
+    32,
+    glium_text::FontTexture::ascii_character_list()
+).unwrap();
 
 // Creating a `TextDisplay` which contains the elements required to draw a specific sentence.
 let text = glium_text::TextDisplay::new(&system, &font, "Hello world!");
@@ -28,6 +34,142 @@ let matrix = [[1.0, 0.0, 0.0, 0.0],
 glium_text::draw(&text, &system, &mut display.draw(), matrix, (1.0, 1.0, 0.0, 1.0));
 # }
 ```
+
+`FontTexture` will rasterize exact characters it's told to.  It can be passed
+anything that implements `IntoIterator<char>` trait.  It is possible to use
+chained ranges with it like this:
+`(0 .. 0x7f+1).chain(0x400 .. 0x4ff+1).filter_map(std::char::from_u32)`
+
+This will rasterize font with characters from "Basic Latin" and "Cyrillic"
+sets.  Here is a complete list of ranges with description.
+
+*As of now, Rust doesn't provide a way to create inclusive ranges yet so thou
+shall add +1 to the outer bound.*
+
+| Start | End   | Description                             |
+|-------+-------+-----------------------------------------|
+|  0000 | 007F  | Basic Latin                             |
+|  0080 | 00FF  | C1 Controls and Latin-1 Supplement      |
+|  0100 | 017F  | Latin Extended-A                        |
+|  0180 | 024F  | Latin Extended-B                        |
+|  0250 | 02AF  | IPA Extensions                          |
+|  02B0 | 02FF  | Spacing Modifier Letters                |
+|  0300 | 036F  | Combining Diacritical Marks             |
+|  0370 | 03FF  | Greek/Coptic                            |
+|  0400 | 04FF  | Cyrillic                                |
+|  0500 | 052F  | Cyrillic Supplement                     |
+|  0530 | 058F  | Armenian                                |
+|  0590 | 05FF  | Hebrew                                  |
+|  0600 | 06FF  | Arabic                                  |
+|  0700 | 074F  | Syriac                                  |
+|  0780 | 07BF  | Thaana                                  |
+|  0900 | 097F  | Devanagari                              |
+|  0980 | 09FF  | Bengali/Assamese                        |
+|  0A00 | 0A7F  | Gurmukhi                                |
+|  0A80 | 0AFF  | Gujarati                                |
+|  0B00 | 0B7F  | Oriya                                   |
+|  0B80 | 0BFF  | Tamil                                   |
+|  0C00 | 0C7F  | Telugu                                  |
+|  0C80 | 0CFF  | Kannada                                 |
+|  0D00 | 0DFF  | Malayalam                               |
+|  0D80 | 0DFF  | Sinhala                                 |
+|  0E00 | 0E7F  | Thai                                    |
+|  0E80 | 0EFF  | Lao                                     |
+|  0F00 | 0FFF  | Tibetan                                 |
+|  1000 | 109F  | Myanmar                                 |
+|  10A0 | 10FF  | Georgian                                |
+|  1100 | 11FF  | Hangul Jamo                             |
+|  1200 | 137F  | Ethiopic                                |
+|  13A0 | 13FF  | Cherokee                                |
+|  1400 | 167F  | Unified Canadian Aboriginal Syllabics   |
+|  1680 | 169F  | Ogham                                   |
+|  16A0 | 16FF  | Runic                                   |
+|  1700 | 171F  | Tagalog                                 |
+|  1720 | 173F  | Hanunoo                                 |
+|  1740 | 175F  | Buhid                                   |
+|  1760 | 177F  | Tagbanwa                                |
+|  1780 | 17FF  | Khmer                                   |
+|  1800 | 18AF  | Mongolian                               |
+|  1900 | 194F  | Limbu                                   |
+|  1950 | 197F  | Tai Le                                  |
+|  19E0 | 19FF  | Khmer Symbols                           |
+|  1D00 | 1D7F  | Phonetic Extensions                     |
+|  1E00 | 1EFF  | Latin Extended Additional               |
+|  1F00 | 1FFF  | Greek Extended                          |
+|  2000 | 206F  | General Punctuation                     |
+|  2070 | 209F  | Superscripts and Subscripts             |
+|  20A0 | 20CF  | Currency Symbols                        |
+|  20D0 | 20FF  | Combining Diacritical Marks for Symbols |
+|  2100 | 214F  | Letterlike Symbols                      |
+|  2150 | 218F  | Number Forms                            |
+|  2190 | 21FF  | Arrows                                  |
+|  2200 | 22FF  | Mathematical Operators                  |
+|  2300 | 23FF  | Miscellaneous Technical                 |
+|  2400 | 243F  | Control Pictures                        |
+|  2440 | 245F  | Optical Character Recognition           |
+|  2460 | 24FF  | Enclosed Alphanumerics                  |
+|  2500 | 257F  | Box Drawing                             |
+|  2580 | 259F  | Block Elements                          |
+|  25A0 | 25FF  | Geometric Shapes                        |
+|  2600 | 26FF  | Miscellaneous Symbols                   |
+|  2700 | 27BF  | Dingbats                                |
+|  27C0 | 27EF  | Miscellaneous Mathematical Symbols-A    |
+|  27F0 | 27FF  | Supplemental Arrows-A                   |
+|  2800 | 28FF  | Braille Patterns                        |
+|  2900 | 297F  | Supplemental Arrows-B                   |
+|  2980 | 29FF  | Miscellaneous Mathematical Symbols-B    |
+|  2A00 | 2AFF  | Supplemental Mathematical Operators     |
+|  2B00 | 2BFF  | Miscellaneous Symbols and Arrows        |
+|  2E80 | 2EFF  | CJK Radicals Supplement                 |
+|  2F00 | 2FDF  | Kangxi Radicals                         |
+|  2FF0 | 2FFF  | Ideographic Description Characters      |
+|  3000 | 303F  | CJK Symbols and Punctuation             |
+|  3040 | 309F  | Hiragana                                |
+|  30A0 | 30FF  | Katakana                                |
+|  3100 | 312F  | Bopomofo                                |
+|  3130 | 318F  | Hangul Compatibility Jamo               |
+|  3190 | 319F  | Kanbun (Kunten)                         |
+|  31A0 | 31BF  | Bopomofo Extended                       |
+|  31F0 | 31FF  | Katakana Phonetic Extensions            |
+|  3200 | 32FF  | Enclosed CJK Letters and Months         |
+|  3300 | 33FF  | CJK Compatibility                       |
+|  3400 | 4DBF  | CJK Unified Ideographs Extension A      |
+|  4DC0 | 4DFF  | Yijing Hexagram Symbols                 |
+|  4E00 | 9FAF  | CJK Unified Ideographs                  |
+|  A000 | A48F  | Yi Syllables                            |
+|  A490 | A4CF  | Yi Radicals                             |
+|  AC00 | D7AF  | Hangul Syllables                        |
+|  D800 | DBFF  | High Surrogate Area                     |
+|  DC00 | DFFF  | Low Surrogate Area                      |
+|  E000 | F8FF  | Private Use Area                        |
+|  F900 | FAFF  | CJK Compatibility Ideographs            |
+|  FB00 | FB4F  | Alphabetic Presentation Forms           |
+|  FB50 | FDFF  | Arabic Presentation Forms-A             |
+|  FE00 | FE0F  | Variation Selectors                     |
+|  FE20 | FE2F  | Combining Half Marks                    |
+|  FE30 | FE4F  | CJK Compatibility Forms                 |
+|  FE50 | FE6F  | Small Form Variants                     |
+|  FE70 | FEFF  | Arabic Presentation Forms-B             |
+|  FF00 | FFEF  | Halfwidth and Fullwidth Forms           |
+|  FFF0 | FFFF  | Specials                                |
+| 10000 | 1007F | Linear B Syllabary                      |
+| 10080 | 100FF | Linear B Ideograms                      |
+| 10100 | 1013F | Aegean Numbers                          |
+| 10300 | 1032F | Old Italic                              |
+| 10330 | 1034F | Gothic                                  |
+| 10380 | 1039F | Ugaritic                                |
+| 10400 | 1044F | Deseret                                 |
+| 10450 | 1047F | Shavian                                 |
+| 10480 | 104AF | Osmanya                                 |
+| 10800 | 1083F | Cypriot Syllabary                       |
+| 1D000 | 1D0FF | Byzantine Musical Symbols               |
+| 1D100 | 1D1FF | Musical Symbols                         |
+| 1D300 | 1D35F | Tai Xuan Jing Symbols                   |
+| 1D400 | 1D7FF | Mathematical Alphanumeric Symbols       |
+| 20000 | 2A6DF | CJK Unified Ideographs Extension B      |
+| 2F800 | 2FA1F | CJK Compatibility Ideographs Supplement |
+| E0000 | E007F | Tags                                    |
+| E0100 | E01EF | Variation Selectors Supplement          |
 
 */
 
@@ -58,6 +200,7 @@ pub struct FontTexture {
 
 #[derive(Debug)]
 pub enum Error {
+    /// A glyph for this character is not present in font.
     NoGlyph(char),
 }
 
@@ -136,6 +279,10 @@ impl FontTexture {
     }
 
     /// Creates a new texture representing a font stored in a `FontTexture`.
+    /// This function is very expensive as it needs to rasterize font into a
+    /// texture.  Complexity grows as `font_size**2 * characters_list.len()`.
+    /// **Avoid rasterizing everything at once as it will be slow and end up in
+    /// out of memory abort.**
     pub fn new<R, F, I>(facade: &F, font: R, font_size: u32, characters_list: I)
                         -> Result<FontTexture, Error>
         where R: Read, F: Facade, I: IntoIterator<Item=char>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,10 +363,16 @@ impl<F> TextDisplay<F> where F: Deref<Target=FontTexture> {
 /// One unit in height corresponds to a line of text, but the text can go above or under.
 /// The bottom of the line is at `0.0`, the top is at `1.0`.
 /// You need to adapt your matrix by taking these into consideration.
-pub fn draw<F, S: ?Sized, M>(text: &TextDisplay<F>, system: &TextSystem, target: &mut S,
-                             matrix: M, color: (f32, f32, f32, f32))
-                             where S: glium::Surface, M: Into<[[f32; 4]; 4]>,
-                                   F: Deref<Target=FontTexture>
+pub fn draw<F, S: ?Sized, M>(
+    text: &TextDisplay<F>,
+    system: &TextSystem,
+    target: &mut S,
+    matrix: M,
+    color: (f32, f32, f32, f32)
+) -> Result<(), glium::DrawError>
+    where S: glium::Surface,
+          M: Into<[[f32; 4]; 4]>,
+          F: Deref<Target=FontTexture>
 {
     let matrix = matrix.into();
 
@@ -412,8 +418,7 @@ pub fn draw<F, S: ?Sized, M>(text: &TextDisplay<F>, system: &TextSystem, target:
             .. Default::default()
         }
     };
-    target.draw(vertex_buffer, index_buffer, &system.program, &uniforms,
-                &params).unwrap();
+    target.draw(vertex_buffer, index_buffer, &system.program, &uniforms, &params)
 }
 
 unsafe fn build_font_image(font: rusttype::Font, characters_list: Vec<char>, font_size: u32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,7 @@ pub fn draw<F, S: ?Sized, M>(
         magnify_filter: glium::uniforms::MagnifySamplerFilter::Linear,
         minify_filter: glium::uniforms::MinifySamplerFilter::Linear,
         .. Default::default()
-    }
+    };
 
     let params = {
         use glium::BlendingFunction::Addition;
@@ -432,7 +432,7 @@ pub fn draw_with_params<F, S: ?Sized, M>(
 
     // returning if nothing to draw
     if is_empty || vertex_buffer.is_none() || index_buffer.is_none() {
-        return;
+        return Ok(());
     }
 
     let vertex_buffer = vertex_buffer.as_ref().unwrap();


### PR DESCRIPTION
This PR brings series of enhancements, which include increased robustness, flexibility, rasterization performance and somewhat richer documentation.

Changes:

0. `FontTexture::new` was made generic and takes any object that implements `IntoIterator<char>` trait.  It was also made more lazy and doesn't prematurely consume the collection anymore.
1. `FontTexture::new` will return an error instead of crashing when font doesn't contain glyph for requested character(s).
2. `characters_infos` was made to use `HashMap` internally so `TextDisplay::set_text` complexity now grows as O(n) instead of O(m * n) where m = `characters_infos` and n is `text`.
3. `glium_text::draw` was made to return `Result<(), glium::DrawError>` instead of not returning anything and crashing on failed draw.
4. `glium_text::draw_with_params` was added, which takes user-supplied `SamplerBehavior` and `DrawParameters` to allow greater flexibility when needed.
5. Bounding box fix 953c71d080b305dbd844fa9d45be5eefe6deb95b was included.
6. Bumped package version.

I think it is time the package version can be bumped to "0.1.0"? :-)