### PR TITLE
Bump glium version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "glium_text_rusttype"
-version = "0.3.3"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "Fedor Logachev <not.fl3@gmail.com>", "Constantine Shablya <t3a@protonmail.com>"]
 description = "glium_text fork, text drawing with glium and rusttype"
 documentation = "https://docs.rs/glium_text_rusttype"
-repository = "https://github.com/not-fl3/glium_text_rusttype"
 keywords = ["text", "opengl"]
 license = "MIT"
+name = "glium_text_rusttype"
+repository = "https://github.com/not-fl3/glium_text_rusttype"
+version = "0.3.4"
 
 [dependencies]
 rusttype = "0.8"
 
 [dependencies.glium]
-version = "0.26"
 default-features = false
+version = "0.28"
 
 [dev-dependencies]
 cgmath = "0.17"
 
 [dev-dependencies.glium]
-version = "0.26"
 features = ["glutin"]
+version = "0.28"


### PR DESCRIPTION
Recent glium versions are causing version mismatches with this package, despite no material changes having occurred. Bump the glium version to keep the dependency trees happy...